### PR TITLE
Update workshop examples so they produce a single lineage graph

### DIFF
--- a/airflow/e2-lineage-api/generate-events.py
+++ b/airflow/e2-lineage-api/generate-events.py
@@ -12,12 +12,13 @@ client = OpenLineageClient.from_environment()
 producer = "https://github.com/OpenLineage/workshops"
 
 # Create some basic Dataset objects for our fictional pipeline
-online_orders = Dataset(namespace="workshop", name="online_orders")
-mail_orders = Dataset(namespace="workshop", name="mail_orders")
-orders = Dataset(namespace="workshop", name="orders")
+monthly_summary = Dataset(namespace="postgres://workshop-db:None", name="workshop.public.monthly_summary")
+commissions = Dataset(namespace="postgres://workshop-db:None", name="workshop.public.commissions")
+taxes = Dataset(namespace="postgres://workshop-db:None", name="workshop.public.taxes")
+
 
 # Create a Job object
-job = Job(namespace="workshop", name="process_orders")
+job = Job(namespace="workshop", name="monthly_accounting")
 
 # Create a Run object with a unique ID
 run = Run(str(uuid4()))
@@ -41,7 +42,7 @@ client.emit(
         RunState.COMPLETE,
         datetime.now().isoformat(),
         run, job, producer,
-        inputs=[online_orders, mail_orders],
-        outputs=[orders],
+        inputs=[monthly_summary],
+        outputs=[commissions, taxes],
     )
 )

--- a/airflow/e2-lineage-api/json/completejob.json
+++ b/airflow/e2-lineage-api/json/completejob.json
@@ -5,12 +5,12 @@
     "runId": "d46e465b-d358-4d32-83d4-df660ff614dd"
   },
   "job": {
-    "namespace": "my-namespace",
-    "name": "my-job"
+    "namespace": "workshop",
+    "name": "process_taxes"
   },
   "outputs": [{
-    "namespace": "my-namespace",
-    "name": "my-output"
+    "namespace": "postgres://workshop-db:None",
+    "name": "workshop.public.unpaid_taxes"
   }],     
   "producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client"
 }

--- a/airflow/e2-lineage-api/json/startjob.json
+++ b/airflow/e2-lineage-api/json/startjob.json
@@ -5,12 +5,12 @@
     "runId": "d46e465b-d358-4d32-83d4-df660ff614dd"
   },
   "job": {
-    "namespace": "my-namespace",
-    "name": "my-job"
+    "namespace": "workshop",
+    "name": "process_taxes"
   },
   "inputs": [{
-    "namespace": "my-namespace",
-    "name": "my-input"
+    "namespace": "postgres://workshop-db:None",
+    "name": "workshop.public.taxes"
   }],  
   "producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client"
 }


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross@datakin.com>

By updating a few spots, the workshop attendees might wind up with a single, connected graph!

<img width="1524" alt="Screen Shot 2022-06-07 at 1 06 37 AM" src="https://user-images.githubusercontent.com/1434475/172300197-cf1d4317-34ef-4eb5-a90b-a6f1fddf2e4c.png">
