### PR TITLE
Pin OpenLineage to 0.8.2

### DIFF
--- a/airflow/e3-airflow/Dockerfile
+++ b/airflow/e3-airflow/Dockerfile
@@ -1,3 +1,3 @@
 FROM apache/airflow:2.3.0
-RUN pip install --no-cache-dir openlineage-airflow
+RUN pip install --no-cache-dir openlineage-airflow==0.8.2
 RUN pip install --no-cache-dir openlineage-sql


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross@datakin.com>

I have noticed that the example in `airflow/e3` does not work with OpenLineage 0.9.0 - tasks remain in the running state, and never report lineage to Marquez 🤔

This pins `openlineage-airflow` to 0.8.2, which works for me. I think if @merobi-hub sees an issue w/0.9.0 as well, we should merge this in advance of the next workshop for the attendees.