### PR TITLE
remove alert in column lineage notebook

### DIFF
--- a/spark/column-lineage-oct-2022.ipynb
+++ b/spark/column-lineage-oct-2022.ipynb
@@ -424,20 +424,10 @@
    "source": [
     "dataset_c_encoded_name = urllib.parse.quote_plus(\"/home/jovyan/notebooks/spark-warehouse/dataset_c\");\n",
     "\n",
-    "# print(json.dumps(requests.get(\n",
-    "#     \"{}/api/v1/column-lineage?nodeId=datasetField:file:{}:col_4&withDownstream=true\"\n",
-    "#     .format(marquez_url, dataset_c_encoded_name)\n",
-    "# ).json(), indent=2))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "571edcc8",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-block alert-danger\">\n",
-    "<b>Alert:</b> Downstream lineage has a bug. The same edge is being traversed up and down resulting in multiple input fields for `dataset_b:col_3`. Still work in progress.\n",
-    "</div>"
+    "print(json.dumps(requests.get(\n",
+    "    \"{}/api/v1/column-lineage?nodeId=datasetField:file:{}:col_4&withDownstream=true\"\n",
+    "    .format(marquez_url, dataset_c_encoded_name)\n",
+    ").json(), indent=2))"
    ]
   },
   {


### PR DESCRIPTION
Alert is no longer needed, corresponding bug has been solved. 

Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>